### PR TITLE
Fixing the premature exit

### DIFF
--- a/src/bin/smbios-token-ctl
+++ b/src/bin/smbios-token-ctl
@@ -5,6 +5,8 @@
   #
   # Copyright (c) 2005 Dell Computer Corporation
   # Dual Licenced under GNU GPL and OSL
+  #   
+  # Some mod by Rakovskij Stanislav, 2018, rakovskij.stanislav@gmail.com
   #
   #############################################################################
 """smbios-token-ctl"""
@@ -229,6 +231,10 @@ def dumpTokens(tokenTable, tokenXlator, options):
             print(_("  value: %s = %s") % (type, cli.makePrintable(value)))
         except RuntimeError as e:
             pass
+        except Exception as e:
+            print("   Kitten exception:", e)
+            print("    Do not worry if this problem is not for every token.")
+            print("    Possibly you cannot use this token because of your bios does not support it or your OS handle it by self.") 
 
         desc = _("   Desc: ")
         sys.stdout.write(desc)


### PR DESCRIPTION
Dell Latitude E6430, Bios A22. There was a problem with some tokens: https://github.com/dell/libsmbios/issues/55
This commit fixes premature exit, allowing to show full list of tokens, even if we have no permissions to read and edit some of them.